### PR TITLE
New patch version (0.3.1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ prove.py
 output
 validation_output
 tmp
+oc_validator/interface/tmp.py
 
 **/__pycache__/
 

--- a/oc_validator/interface/invalid-template.html
+++ b/oc_validator/interface/invalid-template.html
@@ -3,7 +3,11 @@
 <head>
     <title>Validation output visualiser</title>
     <link crossorigin="anonymous" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" rel="stylesheet"/>
-    <link rel="stylesheet" href="style.css"/>
+    <!-- <link rel="stylesheet" href="style.css"/> -->
+    <!-- integrate stylesheet into HTML page via templating -->
+    <style>
+{{ stylesheet }}
+    </style>
 </head>
 <body>
     <div class="general-info container-fluid">
@@ -17,5 +21,9 @@
     </div>
     <script crossorigin="anonymous" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
 </body>
-<script src="script.js"></script>
+<!-- <script src="script.js"></script> -->
+<!-- integrate JS script into HTML page via templating -->
+<script>
+{{ script }}
+</script>
 </html>

--- a/oc_validator/interface/script.js
+++ b/oc_validator/interface/script.js
@@ -1,24 +1,24 @@
-document.addEventListener('click', function(event) {
-    const element = event.target;
-    const onclickAttr = element.getAttribute('onclick');
+    document.addEventListener('click', function(event) {
+        const element = event.target;
+        const onclickAttr = element.getAttribute('onclick');
 
-    if (!onclickAttr || !onclickAttr.includes('highlightInvolvedElements(this)')) {
-        document.querySelectorAll('.highlight').forEach(el => {
-            el.classList.remove('highlight');
-        });
-    }
-});
+        if (!onclickAttr || !onclickAttr.includes('highlightInvolvedElements(this)')) {
+            document.querySelectorAll('.highlight').forEach(el => {
+                el.classList.remove('highlight');
+            });
+        }
+    });
 
-function highlightInvolvedElements(element) {
-    const classList = element.className.split(' ');
-    const targetClass = classList.find(className => className.startsWith('err-idx-'));
-    if (targetClass) {
-        document.querySelectorAll('.highlight').forEach(el => {
-            el.classList.remove('highlight');
-        });
-        const elements = document.querySelectorAll('.' + targetClass);
-        elements.forEach(el => {
-            el.classList.add('highlight');
-        });
+    function highlightInvolvedElements(element) {
+        const classList = element.className.split(' ');
+        const targetClass = classList.find(className => className.startsWith('err-idx-'));
+        if (targetClass) {
+            document.querySelectorAll('.highlight').forEach(el => {
+                el.classList.remove('highlight');
+            });
+            const elements = document.querySelectorAll('.' + targetClass);
+            elements.forEach(el => {
+                el.classList.add('highlight');
+            });
+        }
     }
-}

--- a/oc_validator/interface/style.css
+++ b/oc_validator/interface/style.css
@@ -1,42 +1,42 @@
-.counter-par {
-    text-align: center;
-    font-size: larger;
-}
-.error-counter {
-    font-size: larger;
-}
-table {
-    margin: 1em 1em 1em 1em;
-    border: 1px solid black;
-}
-th {
-    font-style: italic;
-}
-td, th {
-    border: 1px solid black; padding: 0.3em;
-}
-.error-icon {
-    display: inline-block;
-    width: 0.8em;
-    height: 0.8em;
-    margin-right: 0.1em;
-    margin-left: 0.1em;
-}
-.highlight.error span {
-    background-color: lightcoral;
-}
-.highlight.warning span {
-    background-color: orange;
-}
-.invalid-data.error {
-    display: inline-block;
-    text-decoration: underline;
-    text-decoration-color: LightCoral;
-    text-decoration-thickness: 0.1em;
-}
-.invalid-data.warning {
-    display: inline-block;
-    text-decoration: underline;
-    text-decoration-color: Orange;
-    text-decoration-thickness: 0.1em;
-}
+        .counter-par {
+            text-align: center;
+            font-size: larger;
+        }
+        .error-counter {
+            font-size: larger;
+        }
+        table {
+            margin: 1em 1em 1em 1em;
+            border: 1px solid black;
+        }
+        th {
+            font-style: italic;
+        }
+        td, th {
+            border: 1px solid black; padding: 0.3em;
+        }
+        .error-icon {
+            display: inline-block;
+            width: 0.8em;
+            height: 0.8em;
+            margin-right: 0.1em;
+            margin-left: 0.1em;
+        }
+        .highlight.error span {
+            background-color: lightcoral;
+        }
+        .highlight.warning span {
+            background-color: orange;
+        }
+        .invalid-data.error {
+            display: inline-block;
+            text-decoration: underline;
+            text-decoration-color: LightCoral;
+            text-decoration-thickness: 0.1em;
+        }
+        .invalid-data.warning {
+            display: inline-block;
+            text-decoration: underline;
+            text-decoration-color: Orange;
+            text-decoration-thickness: 0.1em;
+        }

--- a/oc_validator/main.py
+++ b/oc_validator/main.py
@@ -60,6 +60,9 @@ class Validator:
                      data):
                 process_type = 'cits_csv'
                 return process_type
+            elif all(set(row.keys()) == {'citing_id', 'cited_id'} for row in data): # support also Index tables with no publication dates
+                process_type = 'cits_csv'
+                return process_type
             else:
                 return process_type
         except KeyError:
@@ -72,7 +75,7 @@ class Validator:
         elif self.table_to_process == 'cits_csv':
             return self.validate_cits()
         else:
-            return "The input table is not processable, since it does not comply with neither META-CSV nor CITS-CSV basic structure"
+            print("The input table is not processable, since it does not comply with neither META-CSV nor CITS-CSV basic structure.")
 
     def validate_meta(self) -> list:
         """
@@ -525,7 +528,7 @@ class Validator:
 
         # write error_final_report to external JSON file
         with open(join(self.output_dir, 'out_validate_meta.json'), 'w', encoding='utf-8') as f:
-            dump(error_final_report, f)
+            dump(error_final_report, f, indent=4)
 
         # write human-readable validation summary to txt file
         textual_report = self.helper.create_validation_summary(error_final_report)
@@ -666,7 +669,7 @@ class Validator:
 
         # write error_final_report to external JSON file
         with open(join(self.output_dir, 'out_validate_cits.json'), 'w', encoding='utf-8') as f:
-            dump(error_final_report, f)
+            dump(error_final_report, f, indent=4)
 
         # write human-readable validation summary to txt file
         textual_report = self.helper.create_validation_summary(error_final_report)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "oc-validator"
-version = "0.3.0"
+version = "0.3.1"
 description = "A software to validate CSV documents storing citation data and bibliographic metadata according to the OpenCitations Data Model."
 authors = ["Elia Rizzetto <elia.rizzetto@gmail.com>", "Silvio Peroni <silvio.peroni@unibo.it>"]
 readme = "README.md"


### PR DESCRIPTION
- added support for citations table with two columns, named mandatorily _citing_id_ and _cited_id_. The validator does not support citations tables with only three columns (i.e. _citing_id_, _cited_id_ and _citing_publication_date_) although some of the provided files were structured as such. It is still possible to submit regular tables with 4 columns (_citing_id_, _citing_publication_date_, _cited_id_, _cited_publication_date_) and just leave the fields storing the publication dates blank.
- added support for other separators in CSV table (CSVs with ";" separator are now supported)
- other minor changes and bugfix for the interface (especially for the GUI modules). Specifically, see https://github.com/opencitations/oc_validator/commit/6880bb0edd8f604bbdcfd050d60f4a991f7107cd.
- the PiPy package (version 0.3.1) has been also updated to the current state of the software