### PR TITLE
version 0.3.7: raise csv.field_size_limit for larger table fields

### DIFF
--- a/oc_validator/main.py
+++ b/oc_validator/main.py
@@ -12,7 +12,7 @@
 # ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS
 # SOFTWARE.
 
-from csv import DictReader
+from csv import DictReader, field_size_limit
 from yaml import full_load
 from json import load, dump
 from os.path import exists, join, dirname, abspath
@@ -79,6 +79,7 @@ class Validator:
         self.verify_id_existence = verify_id_existence
 
     def read_csv(self, csv_doc, del_position=0):
+        field_size_limit(100000000)  # sets 100 MB as size limit for parsing larger csv fields
         delimiters_to_try=[',',';','\t']
         with open(csv_doc, 'r', encoding='utf-8') as f:
             data_dict = list(DictReader(f, delimiter=delimiters_to_try[del_position]))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "oc-validator"
-version = "0.3.6"
+version = "0.3.7"
 description = "A software to validate CSV documents storing citation data and bibliographic metadata according to the OpenCitations Data Model."
 authors = ["Elia Rizzetto <elia.rizzetto@gmail.com>", "Silvio Peroni <silvio.peroni@unibo.it>"]
 readme = "README.md"


### PR DESCRIPTION
the default max size for csv fields in csv library is 131072 bytes. I've set it to 100 MB to seamlessly read larger fields (see e.g. the  the 3607 authors of doi:10.1093/bjs/znaa051).