### PR TITLE
version 0.3.10: more robust SPARQL queries and better HTML vis

### DIFF
--- a/oc_validator/id_existence.py
+++ b/oc_validator/id_existence.py
@@ -121,12 +121,15 @@ class IdExistence:
         q = '''
         PREFIX datacite: <http://purl.org/spar/datacite/>
         PREFIX literal: <http://www.essepuntato.it/2010/06/literalreification/>
+        PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
         ASK {
-            ?identifier literal:hasLiteralValue "%s".
-            ?res datacite:hasIdentifier ?identifier.
-            ?identifier datacite:usesIdentifierScheme datacite:%s.
+            VALUES ?val { "%s" "%s"^^xsd:string }
+            ?identifier literal:hasLiteralValue ?val .
+            ?res datacite:hasIdentifier ?identifier .
+            ?identifier datacite:usesIdentifierScheme datacite:%s .
         }
-        ''' % (lookup_id, datacite_id_scheme)
+        ''' % (lookup_id, lookup_id, datacite_id_scheme)
 
         for attempt in range(retries):
             try:

--- a/oc_validator/interface/gui.py
+++ b/oc_validator/interface/gui.py
@@ -30,7 +30,7 @@ def make_html_row(row_idx, row):
                 items = value.split()
                 for idx, item in enumerate(items):
                     s = f'<span class="item"><span class="item-component">{item}</span></span>'
-                    new_value = new_value.replace(item, s)
+                    new_value = new_value.replace(item, s) if s not in new_value else new_value # to handle in-field duplicates
                 new_value = f'<span class="field-value {col_name}">{new_value}</span>'
 
             elif col_name in ['author', 'editor', 'publisher']:
@@ -52,7 +52,7 @@ def make_html_row(row_idx, row):
                         new_value = new_value.replace(item, s)
                     else:
                         s = f'<span class="item"><span class="item-component">{item}</span></span>'
-                        new_value = new_value.replace(item, s)
+                        new_value = new_value.replace(item, s) if s not in new_value else new_value # to handle in-field duplicates
 
                 new_value = f'<span class="field-value {col_name}">{new_value}</span>'
                 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "oc-validator"
-version = "0.3.9"
+version = "0.3.10"
 description = "A software to validate CSV documents storing citation data and bibliographic metadata according to the OpenCitations Data Model."
 authors = ["Elia Rizzetto <elia.rizzetto@gmail.com>", "Silvio Peroni <silvio.peroni@unibo.it>"]
 readme = "README.md"


### PR DESCRIPTION
Actual data in the triplestore demands SPARQL queries looking for literal values (e.g. DOIs) to look both for literals with an explicitit xsd:string datatype AND for literal with no specified xsd datatype.  -> changed SPARQL queries in id_existence.IdExistence.query_meta_triplestore().

Errors for in-field duplicates (e.g. duplicate_ra) were not correctly represented in the HTML rendering of the validation report. -> fixed.

