### PR TITLE
optimize get_duplicates_meta; v. 0.3.11 > 0.3.12

### DIFF
--- a/oc_validator/csv_wellformedness.py
+++ b/oc_validator/csv_wellformedness.py
@@ -460,48 +460,94 @@ class Wellformedness:
 
         return report
 
+    # # THIS FUNCTION IS THE OLD FUNCTION TO GET DUPLICATES, KEPT HERE FOR REFERENCE.
+    # def get_duplicates_meta(self, entities: list, data_dict: list, messages) -> list:
+    #     """
+    #     Creates a list of dictionaries containing the duplication error in the whole document between two or more rows.
+    #     :param entities: list containing sets of strings (the IDs), where each set corresponds to a bibliographic entity.
+    #     :param data_dict: the list of the document's rows, read as dictionaries
+    #     :param messages: the dictionary containing the messages as they're read from the .yaml config file
+    #     :return: list of dictionaries, each carrying full info about each duplication error within the document.
+    #     """
+    #     visited_dicts = []
+    #     report = []
+    #     for row_idx, row in enumerate(data_dict):
+    #         br = {'meta_id': None, 'table': {}}
+    #         items = row['id'].split(' ')
+
+    #         for item in items:
+    #             if not br['meta_id']:
+    #                 for set_idx, set in enumerate(entities):
+    #                     if item in set:  # mapping the single ID to its corresponding set representing the bibl. entity
+    #                         br['meta_id'] = str(set_idx)
+    #                         br['table'] = {row_idx: {'id': list(range(len(items)))}}
+    #                         break
+
+    #         # process row only if a meta_id has been associated to it (i.e. id field contains at least one valid identifier)
+    #         if br['meta_id']:
+    #             if not visited_dicts:  # just for the first round of the iteration (when visited_dicts is empty)
+    #                 visited_dicts.append(br)
+    #             else:
+    #                 for visited_br_idx, visited_br in enumerate(visited_dicts):
+    #                     if br['meta_id'] == visited_br['meta_id']:
+    #                         visited_dicts[visited_br_idx]['table'].update(br['table'])
+    #                         break
+    #                     elif visited_br_idx == (len(visited_dicts) - 1):
+    #                         visited_dicts.append(br)
+
+    #     for d in visited_dicts:
+    #         if len(d['table']) > 1:  # if there's more than 1 row in table for a br (duplicate rows error)
+    #             table = d['table']
+    #             message = messages['m11']
+
+    #             report.append(
+    #                 self.helper.create_error_dict(validation_level='csv_wellformedness', error_type='error',
+    #                                               message=message, error_label='duplicate_br', located_in='row',
+    #                                               table=table))
+
+    #     return report
+
     def get_duplicates_meta(self, entities: list, data_dict: list, messages) -> list:
-        """
-        Creates a list of dictionaries containing the duplication error in the whole document between two or more rows.
-        :param entities: list containing sets of strings (the IDs), where each set corresponds to a bibliographic entity.
-        :param data_dict: the list of the document's rows, read as dictionaries
-        :param messages: the dictionary containing the messages as they're read from the .yaml config file
-        :return: list of dictionaries, each carrying full info about each duplication error within the document.
-        """
-        visited_dicts = []
+        # Build ID → entity index lookup
+        id_to_entity_index = {}
+        for idx, entity_set in enumerate(entities):
+            for id_ in entity_set:
+                id_to_entity_index[id_] = str(idx)
+
+        # Track meta_id → table
+        meta_map = {}
         report = []
+
         for row_idx, row in enumerate(data_dict):
-            br = {'meta_id': None, 'table': {}}
             items = row['id'].split(' ')
 
-            for item in items:
-                if not br['meta_id']:
-                    for set_idx, set in enumerate(entities):
-                        if item in set:  # mapping the single ID to its corresponding set representing the bibl. entity
-                            br['meta_id'] = str(set_idx)
-                            br['table'] = {row_idx: {'id': list(range(len(items)))}}
-                            break
+            # Find first valid ID that maps to an entity
+            meta_id = next((id_to_entity_index.get(item) for item in items if item in id_to_entity_index), None)
 
-            # process row only if a meta_id has been associated to it (i.e. id field contains at least one valid identifier)
-            if br['meta_id']:
-                if not visited_dicts:  # just for the first round of the iteration (when visited_dicts is empty)
-                    visited_dicts.append(br)
-                else:
-                    for visited_br_idx, visited_br in enumerate(visited_dicts):
-                        if br['meta_id'] == visited_br['meta_id']:
-                            visited_dicts[visited_br_idx]['table'].update(br['table'])
-                            break
-                        elif visited_br_idx == (len(visited_dicts) - 1):
-                            visited_dicts.append(br)
+            if meta_id is None:
+                continue  # skip rows with no valid ID
 
-        for d in visited_dicts:
-            if len(d['table']) > 1:  # if there's more than 1 row in table for a br (duplicate rows error)
-                table = d['table']
+            # Build row table
+            row_table = {row_idx: {'id': list(range(len(items)))}}
+
+            if meta_id not in meta_map:
+                meta_map[meta_id] = row_table
+            else:
+                meta_map[meta_id].update(row_table)
+
+        # Collect duplicates
+        for meta_id, table in meta_map.items():
+            if len(table) > 1:
                 message = messages['m11']
-
                 report.append(
-                    self.helper.create_error_dict(validation_level='csv_wellformedness', error_type='error',
-                                                  message=message, error_label='duplicate_br', located_in='row',
-                                                  table=table))
+                    self.helper.create_error_dict(
+                        validation_level='csv_wellformedness',
+                        error_type='error',
+                        message=message,
+                        error_label='duplicate_br',
+                        located_in='row',
+                        table=table
+                    )
+                )
 
         return report

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "oc-validator"
-version = "0.3.11"
+version = "0.3.12"
 description = "A software to validate CSV documents storing citation data and bibliographic metadata according to the OpenCitations Data Model."
 authors = ["Elia Rizzetto <elia.rizzetto@gmail.com>", "Silvio Peroni <silvio.peroni@unibo.it>"]
 readme = "README.md"


### PR DESCRIPTION
Bring the complexity of Wellformedness.get_duplicates_meta() from quadratic to linear time. The previous version of this algorithm, despite being slow, was reasonably "fast" with a high number of smaller files but extremely slow with a single large file. This version should work in both scenarios.