### PR TITLE
bugfix: local IDs

### DIFF
--- a/oc_validator/csv_wellformedness.py
+++ b/oc_validator/csv_wellformedness.py
@@ -222,7 +222,9 @@ class Wellformedness:
         #  of accepted types might change/be extended frequently!
 
         missing = {}
-        if not row['id']:  # ID value is missing
+        ids = row['id'].split(' ')
+        internal_only_id = all(id.startswith('temp:') or id.startswith('local:') for id in ids)
+        if not row['id'] or internal_only_id:  # ID value is missing or only temp/local IDs are specified
 
             if row['type']:  # ID is missing and 'type' is specified
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "oc-validator"
-version = "0.3.12"
+version = "0.3.13"
 description = "A software to validate CSV documents storing citation data and bibliographic metadata according to the OpenCitations Data Model."
 authors = ["Elia Rizzetto <elia.rizzetto@gmail.com>", "Silvio Peroni <silvio.peroni@unibo.it>"]
 readme = "README.md"


### PR DESCRIPTION
Local IDs (with scheme "local" or "temp") were treated like public persistent identifiers for the purpose of identifying an entity. This has been fixed, as they should only be used to map entities between the metadata table and the citation table. --> Now it is mandatory to specify the required metadata for entities that have no other identifier than temp or local.

v. 0.3.12 > 0.3.13