### PR TITLE
bugfix: skip API calls in process executed from CLI

### DIFF
--- a/oc_validator/main.py
+++ b/oc_validator/main.py
@@ -955,7 +955,12 @@ if __name__ == '__main__':
                         help='Skip checking if IDs are registered somewhere, i.e. do not use Meta endpoint nor external APIs.',
                         required=False)
     args = parser.parse_args()
-    v = Validator(args.input_csv, args.output_dir, args.use_meta_endpoint)
+    v = Validator(
+        args.input_csv, 
+        args.output_dir, 
+        args.use_meta_endpoint,
+        args.verify_id_existence,
+    )
     v.validate()
 
 # to instantiate the class, write:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "oc-validator"
-version = "0.3.13"
+version = "0.3.14a0"
 description = "A software to validate CSV documents storing citation data and bibliographic metadata according to the OpenCitations Data Model."
 authors = ["Elia Rizzetto <elia.rizzetto@gmail.com>", "Silvio Peroni <silvio.peroni@unibo.it>"]
 readme = "README.md"


### PR DESCRIPTION
CLI argument for skipping external API calls ("-s"/"--no-id-existence") was not passed to the instance of Validator in main.py executable, resulting in always making API calls when the script was executed from CLI.